### PR TITLE
Round floats to 2 decimal places in output file

### DIFF
--- a/lot.py
+++ b/lot.py
@@ -71,13 +71,16 @@ class Lot(object):
             'Basis', 'SellDate', 'Proceeds', 'AdjCode',
             'Adj', 'FormPosition', 'BuyLot', 'IsReplacement']
   def csv_row(self):
+    decimal_fmt = '%.02f'
     return [self.count, self.symbol, self.description,
             self.buydate.strftime('%m/%d/%Y'),
-            self.basis,
+            decimal_fmt % self.basis,
             None if self.selldate is None else \
             self.selldate.strftime('%m/%d/%Y'),
-            self.proceeds, self.code,
-            self.adjustment, self.form_position,
+            None if self.proceeds is None else decimal_fmt % self.proceeds,
+            self.code,
+            None if self.adjustment is None else decimal_fmt % self.adjustment,
+            self.form_position,
             self.buy_lot, 'True' if self.is_replacement else '']
   def __eq__(self, that):
     if not isinstance(that, self.__class__):


### PR DESCRIPTION
Otherwise the output file contains raw floats when lots are split.

Before:
```
3,GOOG,8 GOOG,01/01/2016,2360.7,01/02/2016,2347.4624999999996,W,13.237500000000182,11.2,2,
                              ^                 ^^^^^^^^^^^^^      ^^^^^^^^^^^^^^^
```

After:
```
3,GOOG,8 GOOG,01/01/2016,2360.70,01/02/2016,2347.46,W,13.24,11.2,2,
                              ^^                 ^^      ^^
```

(the unchanged 11.2 at the end is the lot number, not a dollar value)